### PR TITLE
Improve permssion set

### DIFF
--- a/org.kde.palapeli.json
+++ b/org.kde.palapeli.json
@@ -10,8 +10,7 @@
         "--socket=x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-        "--device=dri",
-        "--filesystem=xdg-config/kdeglobals:ro"
+        "--device=dri"
     ],
     "modules": [
         {

--- a/org.kde.palapeli.json
+++ b/org.kde.palapeli.json
@@ -7,7 +7,7 @@
     "rename-icon": "palapeli",
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
         "--device=dri"


### PR DESCRIPTION
* [Remove filesystem=xdg-config/kdeglobals:ro permission](https://github.com/flathub/org.kde.palapeli/commit/0e572e2a0c28bdf26c3ece52d8afad17f28a6937)

It not needed after kde runtime added this permission for itself years ago.

* [Use fallback-x11 instead of x11 permission](https://github.com/flathub/org.kde.palapeli/commit/6a67ebce127befd17728d77dca249bdc9fa54f26)

This gets rid of "Potentially Unsafe" warning in app stores.